### PR TITLE
Several changes...

### DIFF
--- a/kali.json
+++ b/kali.json
@@ -1,13 +1,12 @@
 {
   "variables": {
-    "aws_access_key": "YOUR-ACCESS-KEY-HERE",
-    "aws_secret_key": "YOUR-SECRET-KEY-HERE",
-    "subnet_id": "YOUR-SUBNET-ID-HERE",
-    "security_group_id": "YOUR-SECURITY-GROUP-ID-HERE", 
-
-    "instance_type": "t2.medium",
+    "aws_access_key": "AKIAI4XUJTEEFR6VUKIQ",
+    "aws_secret_key": "1zGBfpynCWp/SsH8YcYBQ0blt0YI1iqMyh2KOYG1",
+    "security_group_id": "sg-4f48b834", 
+    "subnet_id": "subnet-2dbc8144",
+    "instance_type": "m3.medium",
     "region": "us-east-1",
-    "source_ami": "ami-f0e7d19a"   
+    "source_ami": "ami-8e9ca3e4"   
   },
 
   "builders": [{
@@ -32,7 +31,9 @@
           "volume_type": "gp2",
           "device_name": "/dev/xvda",
 	  "delete_on_termination": "true"          
-	  }]
+	  }],
+    "vpc_id": "vpc-53bc813a",
+    "associate_public_ip_address": true
   }],
   
   "provisioners": [{

--- a/kali.json
+++ b/kali.json
@@ -1,10 +1,10 @@
 {
   "variables": {
-    "aws_access_key": "AKIAI4XUJTEEFR6VUKIQ",
-    "aws_secret_key": "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",
-    "security_group_id": "sg-4f48b834", 
-    "subnet_id": "subnet-2dbc8144",
-    "instance_type": "m3.medium",
+    "aws_access_key": "YOUR-ACCESS-KEY-HERE",
+    "aws_secret_key": "YOUR-SECRET-KEY-HERE",
+    "subnet_id": "YOUR-SUBNET-ID-HERE",
+    "security_group_id": "YOUR-SECURITY-GROUP-ID-HERE", 
+    "instance_type": "t2.medium",
     "region": "us-east-1",
     "source_ami": "ami-8e9ca3e4"   
   },

--- a/kali.json
+++ b/kali.json
@@ -3,7 +3,8 @@
     "aws_access_key": "YOUR-ACCESS-KEY-HERE",
     "aws_secret_key": "YOUR-SECRET-KEY-HERE",
     "subnet_id": "YOUR-SUBNET-ID-HERE",
-    "security_group_id": "YOUR-SECURITY-GROUP-ID-HERE", 
+    "security_group_id": "YOUR-SECURITY-GROUP-ID-HERE",
+    "vpc_id": "YOUR-VPC-ID-HERE",
     "instance_type": "t2.medium",
     "region": "us-east-1",
     "source_ami": "ami-8e9ca3e4"   
@@ -32,7 +33,7 @@
           "device_name": "/dev/xvda",
 	  "delete_on_termination": "true"          
 	  }],
-    "vpc_id": "vpc-53bc813a",
+    "vpc_id": "{{user `vpc_id`}}",
     "associate_public_ip_address": true
   }],
   

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -55,7 +55,7 @@ aptitude -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-con
 aptitude -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install kali-desktop-gnome
 
 #### Update to the newest version of Kali
-aptitude -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" upgrade
+aptitude -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" upgrade
 
 #### Since we're automating via force-confnew, one of the upgrades overwrites our sources.list so fix it again
 #### Overwrite the default Debian mirrors/sources with the Kali mirrors/sources

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -17,7 +17,7 @@ gpg --keyserver pgpkeys.mit.edu --recv-key  ED444FF07D8D0BF6
 gpg -a --export ED444FF07D8D0BF6 | apt-key add -
 
 
-#### Non-interactive frontend to avoid stdin errors.
+#### Non-interactive frontend to avoid stdin errors with debconf.
 export DEBIAN_FRONTEND=noninteractive
 
 #### Update our apt db so we can install kali-keyring
@@ -45,17 +45,17 @@ debconf-set-selections <<< 'kismet kismet/install-users string'
 ## sslh
 debconf-set-selections <<< 'sslh sslh/inetd_or_standalone select standalone'
 
-#### Prevent apt-get from asking us questions while isntalling software
-export DEBIAN_FRONTEND=noninteractive
+#### Install aptitude to automatically resolve dependency issues with the packages below.
+apt-get -y --force-yes install aptitude
 
 #### Install the base software
 ## List taken from the official Kali-live-build script at: http://git.kali.org/gitweb/?p=live-build-config.git;a=blob_plain;f=config/package-lists/kali.list.chroot;hb=HEAD
-apt-get -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install kali-linux
-apt-get -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install kali-linux-full
-apt-get -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install kali-desktop-gnome
+aptitude -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install kali-linux
+aptitude -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install kali-linux-full
+aptitude -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install kali-desktop-gnome
 
 #### Update to the newest version of Kali
-apt-get -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" upgrade
+aptitude -y --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" upgrade
 
 #### Since we're automating via force-confnew, one of the upgrades overwrites our sources.list so fix it again
 #### Overwrite the default Debian mirrors/sources with the Kali mirrors/sources

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -13,6 +13,12 @@ rm -rf /etc/apt/sources.list.d/*
 
 #### Download and import the official Kali Linux key
 wget -q -O - https://www.kali.org/archive-key.asc | gpg --import
+gpg --keyserver pgpkeys.mit.edu --recv-key  ED444FF07D8D0BF6
+gpg -a --export ED444FF07D8D0BF6 | apt-key add -
+
+
+#### Non-interactive frontend to avoid stdin errors.
+export DEBIAN_FRONTEND=noninteractive
 
 #### Update our apt db so we can install kali-keyring
 apt-get update

--- a/scripts/grub.sh
+++ b/scripts/grub.sh
@@ -6,4 +6,4 @@ debconf-set-selections <<< 'grub-installer grub-installer/with_other_os boolean 
 debconf-set-selections <<< 'grub-pc grub-pc/install_devices multiselect /dev/xvda'
 
 # Install grub2
-apt-get -y --force-yes install grub2
+aptitude -y install grub2


### PR DESCRIPTION
- Added vpc_id and associate_public_ip_address to resolve potential SSH issues with non-default VPCs.
- Trusted the Kali key a bit earlier in the script to avoid annoying warnings.
- Moved DEBIAN_FRONTED=noninteractive earlier in the script to prevent stdin issues with debconf
- Installed aptitude before trying to install base packages, to automatically handle dependency issues.
